### PR TITLE
feat(gateway): add instance-aware connection pooling and update key routes

### DIFF
--- a/gateway/config/default.toml
+++ b/gateway/config/default.toml
@@ -3,7 +3,7 @@ url = "redis://127.0.0.1:6379/"
 pool_size = 16  # (có thể không cần, nếu không dùng nữa)
 pool_max_size = 16
 pool_timeout_seconds = 5
-default_password = ""  # Hoặc bỏ dòng này nếu không dùng auth
+default_password = "I1AkA3kACg"  # Hoặc bỏ dòng này nếu không dùng auth
 
 [logging]
 level = "info"

--- a/gateway/src/error.rs
+++ b/gateway/src/error.rs
@@ -22,6 +22,10 @@ pub enum GatewayError {
     #[error("Instance not found: {0}")]
     InstanceNotFound(String),
 
+    #[error("Failed to connect to Redis instance: {0}")]
+    RedisConnectionError(String),
+
+
     #[error("Invalid request: {0}")]
     BadRequest(String),
 
@@ -50,6 +54,7 @@ impl IntoResponse for GatewayError {
             GatewayError::KubeError(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Kubernetes client error: {}", e),),
             GatewayError::CreatePool(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Create pool error: {}", e)),
             GatewayError::SerdeJson(e) => (StatusCode::BAD_REQUEST, format!("JSON error: {}", e)),
+            GatewayError::RedisConnectionError(e) => (StatusCode::BAD_REQUEST, format!("Connect to Redis instance error: {}", e)),
         };
 
         let body = Json(json!({

--- a/gateway/src/handlers/keys.rs
+++ b/gateway/src/handlers/keys.rs
@@ -82,6 +82,7 @@ pub async fn get_key(
     Query(params): Query<MethodOverride>,
     State(state): State<AppState>,
 ) -> Result<Json<serde_json::Value>> {
+    println!("🔑 Đang thực hiện GET key '{}' trên instance '{}'", key, instance_name);
     // Handle method override
     if let Some(method) = &params.method {
         match method.to_uppercase().as_str() {

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -86,12 +86,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Build application router
     let app = Router::new()
-        .route("/set/{key}/{value}", post(set_key))
-        .route("/get/{key}", get(get_key))
+        .route("/{instance_name}/set/{key}", post(set_key))
+        .route("/{instance_name}/get/{key}", get(get_key))
         .route("/healthz", get(health_check))
-        .route(
-            "/metrics",
-            get({
+        .route("/metrics", get({
                 let handle = metrics_handle.clone();
                 move || async move { metrics_endpoint(handle.clone()).await }
             }),


### PR DESCRIPTION
## Summary
This PR refactors Redis integration with **instance-aware connection pooling** and updates key management routes.  
APIs now require an `instance_name` prefix, enabling support for multiple Redis clusters or replicas.

---

## Key Features
- **RedisPoolManager**
  - Manages pools per `instance_name`, with Kubernetes service discovery and localhost fallback.
- **Updated Routes**
  - `POST /:instance/set/:key` → set key (optional TTL).
  - `GET /:instance/get/:key` → get key.
  - `DELETE /:instance/get/:key?method=DELETE` → delete key.


---

## Test Instructions
Ensure Redis is reachable (local dev requires port-forward):

```bash
kubectl port-forward service/my-redis-replicas 6379:6379
